### PR TITLE
Fix test durations.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,12 @@ All the features can be seen in this example:
         freezer.move_to('2017-05-21')
         assert current_date == date(2017, 5, 21)
 
+    def test_not_using_marker(freezer):
+        now = datetime.now()
+        time.sleep(1)
+        later = datetime.now()
+        assert now == later
+
 Contributing
 ------------
 Contributions are very welcome.

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -1,18 +1,44 @@
 # -*- coding: utf-8 -*-
 
 import pytest
+
 from freezegun import freeze_time
 
 
-@pytest.yield_fixture
-def freezer(request):
-    marker = request.node.get_marker('freeze_time')
-    args, kwargs = (marker.args, marker.kwargs) if marker else ((), {})
-    with freeze_time(*marker.args, **marker.kwargs) as freezer:
-        yield freezer
+class FreezegunPlugin(object):
+    def __init__(self):
+        self.freezer = None
+        self.frozen_time = None
+
+    @pytest.fixture(name='freezer')
+    def freezer_fixture(self):
+        if self.frozen_time is not None:
+            yield self.frozen_time
+        else:
+            with freeze_time() as frozen_time:
+                yield frozen_time
+
+    @pytest.hookimpl(tryfirst=True)
+    def pytest_runtest_setup(self, item):
+        marker = item.get_marker('freeze_time')
+
+        if marker:
+            ignore = marker.kwargs.pop('ignore', [])
+            ignore.append('_pytest')
+
+            self.freezer = freeze_time(
+                *marker.args,
+                ignore=ignore,
+                **marker.kwargs
+            )
+            self.frozen_time = self.freezer.start()
+
+    @pytest.hookimpl(trylast=True)
+    def pytest_runtest_teardown(self):
+        if self.freezer is not None:
+            self.freezer.stop()
+            self.freezer = None
+            self.frozen_time = None
 
 
-@pytest.fixture(autouse=True)
-def _auto_freezer(request):
-    if request.node.get_marker('freeze_time'):
-        request.getfixturevalue('freezer')
+plugin = FreezegunPlugin()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     ],
     entry_points={
         'pytest11': [
-            'freezegun = pytest_freezegun',
+            'freezegun = pytest_freezegun:plugin',
         ],
     },
 )

--- a/tests/test_freezegun.py
+++ b/tests/test_freezegun.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import re
+
 from datetime import datetime
 
 
@@ -57,6 +59,67 @@ def test_move_to(testdir):
             assert date.today() == date(2017, 5, 20)
             freezer.move_to('2017-05-21')
             assert date.today() == date(2017, 5, 21)
+    """)
+
+    result = testdir.runpytest('-v', '-s')
+    assert result.ret == 0
+
+
+def test_durations(testdir):
+    """
+    In an older version, the time would be frozen for the pytest itself too.
+    That caused it to report weird durations for test runs,
+    namely very large numbers for setup and very large
+    NEGATIVE numbers for teardown.
+    """
+    testdir.makepyfile("""
+        import pytest
+        from datetime import date, datetime
+
+        @pytest.mark.freeze_time('2000-01-01')
+        def test_truth():
+            assert True
+    """)
+
+    result = testdir.runpytest('-v', '-s', '--durations=3')
+
+    # We don't have access to the actual terminalreporter,
+    # so the only way to collect duration times is
+    # to parse the pytest output.
+    DURATION_REGEX = re.compile(r'''
+        (-?\d+\.\d+)s          # Time in seconds
+        \s+                    # Whitespace
+        (call|setup|teardown)  # Test phase
+        \s+                    # Whitespace
+        test_durations.py::test_truth  # Test ID
+    ''', re.X)
+
+    durations = {}
+    for line in result.outlines:
+        match = DURATION_REGEX.match(line)
+        if match is None:
+            continue
+
+        durations[match.group(2)] = float(match.group(1))
+
+    # It should take a non-negative amount of time for each of the steps,
+    # but it also should never take longer than a second
+    assert 0 <= durations['setup'] <= 1
+    assert 0 <= durations['call'] <= 1
+    assert 0 <= durations['teardown'] <= 1
+
+
+def test_fixture_no_mark(testdir):
+    testdir.makepyfile("""
+        from datetime import datetime
+        import time
+
+        def test_just_fixture(freezer):
+            now = datetime.now()
+            time.sleep(0.1)
+            later = datetime.now()
+
+            assert now == later
     """)
 
     result = testdir.runpytest('-v', '-s')


### PR DESCRIPTION
I noticed that using `pytest-freezegun` causes pytest to report incorrect numbers for durations. This PR fixes this behaviour and also refactors (rewrites?) the plugin to implement pytest hooks instead of an autouse fixture. The refactoring also allowed to use the `freezer` fixture without the mark - it freezes the current time.