### PR TITLE
Fix deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.pytest_cache
 nosetests.xml
 coverage.xml
 *,cover

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -20,7 +20,7 @@ class FreezegunPlugin(object):
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_runtest_setup(self, item):
-        marker = item.get_marker('freeze_time')
+        marker = item.get_closest_marker('freeze_time')
 
         if marker:
             ignore = marker.kwargs.pop('ignore', [])

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -20,7 +20,10 @@ class FreezegunPlugin(object):
 
     @pytest.hookimpl(tryfirst=True)
     def pytest_runtest_setup(self, item):
-        marker = item.get_closest_marker('freeze_time')
+        try:
+            marker = item.get_closest_marker('freeze_time')
+        except AttributeError:  # for pytest < 3.6.0
+            marker = item.get_marker('freeze_time')
 
         if marker:
             ignore = marker.kwargs.pop('ignore', [])

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     py_modules=['pytest_freezegun'],
     install_requires=[
         'freezegun>0.3',
-        'pytest>=3.6.0',
+        'pytest>=3.0.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     py_modules=['pytest_freezegun'],
     install_requires=[
         'freezegun>0.3',
-        'pytest>=3.0.0',
+        'pytest>=3.6.0',
     ],
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,8 @@ commands = coverage run -p -m pytest tests/ {posargs}
 skip_install = true
 deps = flake8
 commands = flake8 pytest_freezegun.py setup.py tests
+
+[pytest]
+filterwarnings =
+    once::DeprecationWarning
+    once::PendingDeprecationWarning


### PR DESCRIPTION
Same as @silverc's https://github.com/ktosiek/pytest-freezegun/pull/4, but this should maintain the original pytest compatibility