### PR TITLE
Bugfix/class based tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [TBC]
+### Added
+- Support for class-based tests
+- Mark is registered
+
+
 ## [0.3.0] - 2018-11-15
 ### Added
 - Support for pytest 3.6+, including 4.0. Thanks to [Oliver Sauder](https://github.com/sliverc) and [Nate Parsons](https://github.com/nsp).

--- a/README.rst
+++ b/README.rst
@@ -31,17 +31,34 @@ You can install "pytest-freezegun" via `pip`_ from `PyPI`_::
 Usage
 -----
 
-All the features can be seen in this example:
+Freeze time by using the ``freezer`` fixture::
 
-.. code-block:: python
+    def test_frozen_date(freezer):
+        now = datetime.now()
+        time.sleep(1)
+        later = datetime.now()
+        assert now == later
+
+This can then be used to move time::
+
+    def test_moving_date(freezer):
+        now = datetime.now()
+        freezer.move_to('2017-05-20')
+        later = datetime.now()
+        assert now != later
+
+You can also pass arguments to freezegun by using the ``freeze_time`` mark::
+
+    @pytest.mark.freeze_time('2017-05-21')
+    def test_current_date():
+        assert date.today() == date(2017, 5, 21)
+
+The ``freezer`` fixture and ``freeze_time`` mark can be used together,
+and they work with other fixtures::
 
     @pytest.fixture
     def current_date():
-        return datetime.now().date()
-
-    @pytest.mark.freeze_time('2017-05-21')
-    def test_current_date(current_date):
-        assert current_date == date(2017, 5, 21)
+        return date.today()
 
     @pytest.mark.freeze_time
     def test_changing_date(current_date, freezer):
@@ -50,18 +67,26 @@ All the features can be seen in this example:
         freezer.move_to('2017-05-21')
         assert current_date == date(2017, 5, 21)
 
-    def test_not_using_marker(freezer):
-        now = datetime.now()
-        time.sleep(1)
-        later = datetime.now()
-        assert now == later
+They can also be used in class-based tests::
+
+    class TestDate:
+
+        @pytest.mark.freeze_time
+        def test_changing_date(self, current_date, freezer):
+            freezer.move_to('2017-05-20')
+            assert current_date == date(2017, 5, 20)
+            freezer.move_to('2017-05-21')
+            assert current_date == date(2017, 5, 21)
+
 
 Contributing
 ------------
+
 Contributions are very welcome.
 Tests can be run with `tox`_.
 You can later check coverage with `coverage combine && coverage html`.
 Please try to keep coverage at least the same before you submit a pull request.
+
 
 License
 -------
@@ -73,6 +98,7 @@ Issues
 ------
 
 If you encounter any problems, please `file an issue`_ along with a detailed description.
+
 
 Credits
 -------

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -5,43 +5,63 @@ import pytest
 from freezegun import freeze_time
 
 
-class FreezegunPlugin(object):
-    def __init__(self):
-        self.freezer = None
-        self.frozen_time = None
-
-    @pytest.fixture(name='freezer')
-    def freezer_fixture(self):
-        if self.frozen_time is not None:
-            yield self.frozen_time
-        else:
-            with freeze_time() as frozen_time:
-                yield frozen_time
-
-    @pytest.hookimpl(tryfirst=True)
-    def pytest_runtest_setup(self, item):
-        try:
-            marker = item.get_closest_marker('freeze_time')
-        except AttributeError:  # for pytest < 3.6.0
-            marker = item.get_marker('freeze_time')
-
-        if marker:
-            ignore = marker.kwargs.pop('ignore', [])
-            ignore.append('_pytest')
-
-            self.freezer = freeze_time(
-                *marker.args,
-                ignore=ignore,
-                **marker.kwargs
-            )
-            self.frozen_time = self.freezer.start()
-
-    @pytest.hookimpl(trylast=True)
-    def pytest_runtest_teardown(self):
-        if self.freezer is not None:
-            self.freezer.stop()
-            self.freezer = None
-            self.frozen_time = None
+PYTEST_VERSION = tuple(int(part) for part in pytest.__version__.split('.'))
+MARKER_NAME = 'freeze_time'
+FIXTURE_NAME = 'freezer'
 
 
-plugin = FreezegunPlugin()
+def get_closest_marker(node, name):
+    """
+    Get our marker, regardless of pytest version
+    """
+    if PYTEST_VERSION < (3, 6, 0):
+        return node.get_marker('freeze_time')
+    else:
+        return node.get_closest_marker('freeze_time')
+
+
+@pytest.fixture(name=FIXTURE_NAME)
+def freezer_fixture(request):
+    """
+    Freeze time and make it available to the test
+    """
+    args = []
+    kwargs = {}
+    ignore = []
+
+    # If we've got a marker, use the arguments provided there
+    marker = get_closest_marker(request.node, MARKER_NAME)
+    if marker:
+        ignore = marker.kwargs.pop('ignore', [])
+        args = marker.args
+        kwargs = marker.kwargs
+
+    # Always want to ignore _pytest
+    ignore.append('_pytest')
+
+    # Freeze time around the test
+    freezer = freeze_time(*args, ignore=ignore, **kwargs)
+    frozen_time = freezer.start()
+    yield frozen_time
+    freezer.stop()
+
+
+def pytest_collection_modifyitems(items):
+    """
+    Inject our fixture into any tests with our marker
+    """
+    for item in items:
+        if (
+            get_closest_marker(item, MARKER_NAME)
+            and FIXTURE_NAME not in item.fixturenames
+        ):
+            item.fixturenames.insert(0, FIXTURE_NAME)
+
+
+def pytest_configure(config):
+    """
+    Register our marker
+    """
+    config.addinivalue_line(
+        "markers", "{}(...): use freezegun to freeze time".format(MARKER_NAME)
+    )

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     ],
     entry_points={
         'pytest11': [
-            'freezegun = pytest_freezegun:plugin',
+            'freezegun = pytest_freezegun',
         ],
     },
 )

--- a/tests/test_freezegun.py
+++ b/tests/test_freezegun.py
@@ -124,3 +124,57 @@ def test_fixture_no_mark(testdir):
 
     result = testdir.runpytest('-v', '-s')
     assert result.ret == 0
+
+
+def test_class_freezing_time(testdir):
+    testdir.makepyfile("""
+        import pytest
+        from datetime import date, datetime
+
+        class TestAsClass(object):
+
+            @pytest.mark.freeze_time('2017-05-20 15:42')
+            def test_sth(self):
+                assert datetime.now().date() == date(2017, 5, 20)
+    """)
+
+    result = testdir.runpytest('-v', '-s')
+    assert result.ret == 0
+
+
+def test_class_move_to(testdir):
+    testdir.makepyfile("""
+        from datetime import date
+        import pytest
+
+        class TestAsClass(object):
+
+            @pytest.mark.freeze_time
+            def test_changing_date(self, freezer):
+                freezer.move_to('2017-05-20')
+                assert date.today() == date(2017, 5, 20)
+                freezer.move_to('2017-05-21')
+                assert date.today() == date(2017, 5, 21)
+    """)
+
+    result = testdir.runpytest('-v', '-s')
+    assert result.ret == 0
+
+
+def test_class_just_fixture(testdir):
+    testdir.makepyfile("""
+        from datetime import datetime
+        import time
+
+        class TestAsClass(object):
+
+            def test_just_fixture(self, freezer):
+                now = datetime.now()
+                time.sleep(0.1)
+                later = datetime.now()
+
+                assert now == later
+    """)
+
+    result = testdir.runpytest('-v', '-s')
+    assert result.ret == 0


### PR DESCRIPTION
I tried to use this package in a class-based test and it failed. I think it was because the fixture was defined on a class method, so when I came to use the fixture it was passed my test class rather than the `FreezegunPlugin` class as expected. I added some tests in b541d96 to confirm it was failing in `pytest-freezegun` rather than in my own code, and that it was just the fixture which was the problem.

I resolved these errors by refactoring the plugin into a single fixture function (`freezer_fixture`) which is also responsible for looking at the mark arguments; this avoids the need for persisting `freezer` and `frozen_time` across function scopes.

This means we don't need the class or plugin singleton any more, so I also removed `plugin` from `setup.py`.

To ensure the mark always works, I also added a function (`pytest_collectcion_modifyitems`) to inject the fixture into any tests which have the mark but not the fixture, thus triggering the logic to look at the mark and freeze time.

I also added a function (`pytest_configure`) to suppress the warnings - I now see this duplicates and will conflict with #14, apologies to dimaqq.

I also took the opportunity to add some details to the usage in the readme to clarify when you may want to use the mark vs the fixture.

Tests are passing locally and it is now working in my project. This has also been tested locally with py3.7, but I have kept that change separate in PR #16.
