### PR TITLE
Support pytest release candidate versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/
@@ -72,3 +73,8 @@ target/
 # pyenv
 .python-version
 
+# direnv
+.envrc
+
+# VSCode
+.vscode

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -21,9 +21,9 @@ def get_closest_marker(node, name):
     Get our marker, regardless of pytest version
     """
     if PYTEST_VERSION < (3, 6, 0):
-        return node.get_marker('freeze_time')
+        return node.get_marker(MARKER_NAME)
     else:
-        return node.get_closest_marker('freeze_time')
+        return node.get_closest_marker(MARKER_NAME)
 
 
 @pytest.fixture(name=FIXTURE_NAME)

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 
+from packaging import version
 import pytest
 
 from freezegun import freeze_time
 
 
-PYTEST_VERSION = tuple(int(part) for part in pytest.__version__.split('.'))
+def _get_pytest_version():
+    v = version.parse(pytest.__version__)
+    return tuple(int(part) for part in v.base_version.split('.'))
+
+
+PYTEST_VERSION = _get_pytest_version()
 MARKER_NAME = 'freeze_time'
 FIXTURE_NAME = 'freezer'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,6 +32,7 @@ py_modules =
 install_requires =
     freezegun>0.3
     pytest>=3.0.0
+    packaging>=15
 
 [options.entry_points]
 pytest11 =

--- a/tests/test_freezegun.py
+++ b/tests/test_freezegun.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
 import re
 
-from datetime import datetime
+import pytest
+from pytest_freezegun import _get_pytest_version
 
 
 def test_freezing_time(testdir):
@@ -256,3 +258,8 @@ def test_class_just_fixture(testdir):
 
     result = testdir.runpytest('-v', '-s')
     assert result.ret == 0
+
+
+def test_parse_pytest_release_candidate_version_string(monkeypatch):
+    monkeypatch.setattr(pytest, "__version__", "6.0.0rc1", raising=True)
+    assert _get_pytest_version() == (6, 0, 0)


### PR DESCRIPTION
Closes #26 

This fix allows the plugin to handle standard version strings in the `x.y.z` format as well as release candidate version strings that look like `x.y.zrc#`.

I used versioning tools from the [packaging](https://pypi.org/project/packaging/) library to parse version string. [This library is used by setuptools and supports PEP 440](https://stackoverflow.com/a/11887885/4326704).

Update:
- With a bit of trial and error on my local machine, I was able to find that `packaging==15` is the earliest version that will work for the change I made.