### PR TITLE
Replace distutils.version with packaging.version's parse

### DIFF
--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from distutils.version import LooseVersion
 from freezegun import freeze_time
+from packaging.version import parse as parse_version
 
 
 MARKER_NAME = 'freeze_time'
@@ -14,7 +14,7 @@ def get_closest_marker(node, name):
     """
     Get our marker, regardless of pytest version
     """
-    if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):
+    if parse_version(pytest.__version__) < parse_version('3.6.0'):
         return node.get_marker('freeze_time')
     else:
         return node.get_closest_marker('freeze_time')

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ py_modules =
     pytest_freezegun
 install_requires =
     freezegun>0.3
+    packaging
     pytest>=3.0.0
 
 [options.entry_points]


### PR DESCRIPTION
Fixes https://github.com/ktosiek/pytest-freezegun/issues/35.

# Demo

```pycon
Python 3.10.0 (v3.10.0:b494f5935c, Oct  4 2021, 14:59:20) [Clang 12.0.5 (clang-1205.0.22.11)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from packaging.version import parse as parse_version
>>> import pytest
>>> parse_version(pytest.__version__)
<Version('6.2.5')>
>>> parse_version('3.6.0')
<Version('3.6.0')>
>>> parse_version(pytest.__version__) < parse_version('3.6.0')
False
```

