### PR TITLE
Drop support for EOL Python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@
 dist: bionic
 language: python
 python:
-  - "3.5"
-  - "3.6"
   - "3.7"
   - "3.8"
   - "pypy3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,14 +3,11 @@
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python35"
-      TOX_ENV: "py35-pt4"
+    - PYTHON: "C:\\Python37"
+      TOX_ENV: "py37-pt3"
 
-    - PYTHON: "C:\\Python36"
-      TOX_ENV: "py36-pt3"
-
-    - PYTHON: "C:\\Python36"
-      TOX_ENV: "py36-pt4"
+    - PYTHON: "C:\\Python37"
+      TOX_ENV: "py37-pt4"
 
     - PYTHON: "C:\\Python38"
       TOX_ENV: "py38-pt5"

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from distutils.version import LooseVersion
@@ -61,5 +59,5 @@ def pytest_configure(config):
     Register our marker
     """
     config.addinivalue_line(
-        "markers", "{}(...): use freezegun to freeze time".format(MARKER_NAME)
+        "markers", f"{MARKER_NAME}(...): use freezegun to freeze time"
     )

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -1,6 +1,5 @@
 import pytest
 
-from distutils.version import LooseVersion
 from freezegun import freeze_time
 
 

--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -8,16 +8,6 @@ MARKER_NAME = 'freeze_time'
 FIXTURE_NAME = 'freezer'
 
 
-def get_closest_marker(node, name):
-    """
-    Get our marker, regardless of pytest version
-    """
-    if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):
-        return node.get_marker('freeze_time')
-    else:
-        return node.get_closest_marker('freeze_time')
-
-
 @pytest.fixture(name=FIXTURE_NAME)
 def freezer_fixture(request):
     """
@@ -28,7 +18,7 @@ def freezer_fixture(request):
     ignore = []
 
     # If we've got a marker, use the arguments provided there
-    marker = get_closest_marker(request.node, MARKER_NAME)
+    marker = request.node.get_closest_marker('freeze_time')
     if marker:
         ignore = marker.kwargs.pop('ignore', [])
         args = marker.args
@@ -50,7 +40,7 @@ def pytest_collection_modifyitems(items):
     Inject our fixture into any tests with our marker
     """
     for item in items:
-        if get_closest_marker(item, MARKER_NAME):
+        if item.get_closest_marker('freeze_time'):
             item.fixturenames.insert(0, FIXTURE_NAME)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,6 @@ classifiers =
     Topic :: Software Development :: Testing
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,3 @@ pytest11 =
 
 [sdist]
 formats = zip
-
-[bdist_wheel]
-universal = 1

--- a/tests/test_freezegun.py
+++ b/tests/test_freezegun.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import re
 
 from datetime import datetime

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = {py35,py36,py37,py38,pypy3}-{pt3,pt4,pt5},py38-ptNext-fgNext,flake8
+envlist = {py37,py38,pypy3}-{pt3,pt4,pt5},py38-ptNext-fgNext,flake8
 
 [testenv]
 deps =


### PR DESCRIPTION
Python 3.5 is failing on the CI, we might as well drop it.

Python 3.6 is EOL in 3 days, we might as well drop that too.


| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.1 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |
| 3.5   | 3.5.10 | 2015-09-30 | 2020-09-13 |


Here's the pip installs for pytest-freezegun from PyPI for November 2021, showing low numbers for 3.5 and 3.6:

| category | percent | downloads |
|:---------|--------:|----------:|
| 3.8      |  32.69% |    75,667 |
| 3.9      |  23.46% |    54,300 |
| null     |  18.85% |    43,635 |
| 3.7      |  15.73% |    36,406 |
| 3.6      |   5.56% |    12,876 |
| 2.7      |   1.95% |     4,508 |
| 3.10     |   1.60% |     3,695 |
| 3.5      |   0.14% |       331 |
| 3.11     |   0.02% |        52 |
| Total    |         |   231,470 |

Date range: 2021-11-01 - 2021-11-30

Source: `pip install -U pypistats && pypistats python_minor pytest-freezegun --last-month`


