### PR TITLE
Require pytest 3.6 to drop dependency on deprecated distutils

### DIFF
--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -2,22 +2,11 @@
 
 import pytest
 
-from distutils.version import LooseVersion
 from freezegun import freeze_time
 
 
 MARKER_NAME = 'freeze_time'
 FIXTURE_NAME = 'freezer'
-
-
-def get_closest_marker(node, name):
-    """
-    Get our marker, regardless of pytest version
-    """
-    if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):
-        return node.get_marker('freeze_time')
-    else:
-        return node.get_closest_marker('freeze_time')
 
 
 @pytest.fixture(name=FIXTURE_NAME)
@@ -30,7 +19,7 @@ def freezer_fixture(request):
     ignore = []
 
     # If we've got a marker, use the arguments provided there
-    marker = get_closest_marker(request.node, MARKER_NAME)
+    marker = request.node.get_closest_marker('freeze_time')
     if marker:
         ignore = marker.kwargs.pop('ignore', [])
         args = marker.args
@@ -52,7 +41,7 @@ def pytest_collection_modifyitems(items):
     Inject our fixture into any tests with our marker
     """
     for item in items:
-        if get_closest_marker(item, MARKER_NAME):
+        if item.get_closest_marker('freeze_time'):
             item.fixturenames.insert(0, FIXTURE_NAME)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ py_modules =
     pytest_freezegun
 install_requires =
     freezegun>0.3
-    pytest>=3.0.0
+    pytest>=3.6
 
 [options.entry_points]
 pytest11 =

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = {py35,py36,py37,py38,pypy3}-{pt3,pt4,pt5},py38-ptNext-fgNext,flake8
 deps =
   coverage
   pip >= 19
-  pt3: pytest>=3,<4
+  pt3: pytest>=3.6,<4
   pt4: pytest>=4,<5
   pt5: pytest>=5,<6
   ptNext: git+https://github.com/pytest-dev/pytest/


### PR DESCRIPTION
Fixes https://github.com/ktosiek/pytest-freezegun/issues/35.
Replaces and closes https://github.com/ktosiek/pytest-freezegun/pull/36.

pytest 3.6 has been out for a long time ([May 23, 2018](https://pypi.org/project/pytest/3.6.0/)), and is now up to 7.1.1.

Let's drop support for pytest 3.0 - 3.5 so we can drop the dependency on distutils which will be removed from Python next year.

(In fact, it's probably safe to drop support for all of pytest 3, and maybe even some of 4-6 and would make maintenance easier.)