### PR TITLE
fix: deprecated distutils Version classes

### DIFF
--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from distutils.version import LooseVersion
+from packaging import version
 from freezegun import freeze_time
 
 
@@ -14,7 +14,7 @@ def get_closest_marker(node, name):
     """
     Get our marker, regardless of pytest version
     """
-    if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):
+    if version.parse(pytest.__version__) < version.parse('3.6.0'):
         return node.get_marker('freeze_time')
     else:
         return node.get_closest_marker('freeze_time')


### PR DESCRIPTION
This pull request includes changes to the `pytest_freezegun.py` file to update the version comparison mechanism from using `LooseVersion` to `packaging.version`.

The most important changes include:

* [`pytest_freezegun.py`](diffhunk://#diff-8c2a0c78b185626f87aca035fe9332fda94a83e39123580893fa0b7acc98dabbL5-R5): Replaced `LooseVersion` from `distutils.version` with `version` from `packaging` for version comparisons.
* [`pytest_freezegun.py`](diffhunk://#diff-8c2a0c78b185626f87aca035fe9332fda94a83e39123580893fa0b7acc98dabbL17-R17): Updated the `get_closest_marker` function to use `version.parse` for comparing `pytest` versions.


Deprecation warning we are currently seeing before the fix:

```bash
DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):
```