### PR TITLE
Use packaging.version instead of distutils.version

### DIFF
--- a/pytest_freezegun.py
+++ b/pytest_freezegun.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 from freezegun import freeze_time
 
 
@@ -14,7 +14,7 @@ def get_closest_marker(node, name):
     """
     Get our marker, regardless of pytest version
     """
-    if LooseVersion(pytest.__version__) < LooseVersion('3.6.0'):
+    if Version(pytest.__version__) < Version('3.6.0'):
         return node.get_marker('freeze_time')
     else:
         return node.get_closest_marker('freeze_time')


### PR DESCRIPTION
Just to get rid of this warning:
![image](https://github.com/user-attachments/assets/c60df891-ab7d-4dd4-bada-878cfe807c19)
